### PR TITLE
fix using same article image multiple times for a category image

### DIFF
--- a/src/db/dao/CategoryHelperDao.php
+++ b/src/db/dao/CategoryHelperDao.php
@@ -76,7 +76,7 @@ class CategoryHelperDao
 
         $imagesResult = $db->query('
                 SELECT
-                     b.cPfad
+                     DISTINCT b.cPfad
                 FROM tartikel a
                 JOIN tartikelpict ap ON 
                     ap.kArtikel = a.kArtikel


### PR DESCRIPTION
* before it was possible when a article was linked multiple times in a Category (for example direct in the category and in a sub-category, ...)