### PR TITLE
prevent reaching php max_execution_time in cron by tracking the execu…

### DIFF
--- a/src/db/dao/CategoryCronJobQueueDao.php
+++ b/src/db/dao/CategoryCronJobQueueDao.php
@@ -10,18 +10,11 @@ class CategoryCronJobQueueDao
 {
     /**
      * @param DbInterface $db
-     * @param int $limit
      * @return Category[]
      */
-    public static function findByLimit(DbInterface $db, int $limit = 120): array
+    public static function findAll(DbInterface $db): array
     {
-        $resultObjects = $db->queryPrepared('
-                SELECT
-                     kKategorie
-                FROM xplugin_t4it_category_image_generation_job_queue                
-                LIMIT :limit',
-            ['limit' => $limit],
-            ReturnType::ARRAY_OF_OBJECTS);
+        $resultObjects = $db->selectAll('xplugin_t4it_category_image_generation_job_queue', [], []);
 
         $categoriesWithoutImage = array();
         foreach ($resultObjects as $resultObject) {


### PR DESCRIPTION
…tion time

* no longer fix chunk-size of 120 cateegories
* the cron aborts the chunk/queue 20 seconds before max_execution_time reached
* 20 seconds to simplify the tracking - because finishing the chunk/queue like cache->flushTags should have enough time